### PR TITLE
fix: vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ const templates = readdirSync("src/templates")
   .filter((name) => existsSync(`src/templates/${name}/index.js`));
 
 const input = Object.fromEntries([
-  ...templates.map((name) => [name, `templates/${name}/index.js`]),
+  ...templates.map((name) => [name, `src/templates/${name}/index.js`]),
   ["shared", "src/index.js"],
 ]);
 
@@ -20,7 +20,7 @@ export default ({ mode }) => ({
   },
 
   build: {
-    outDir: "public/dist",
+    outDir: resolve(process.cwd(), "public/dist"),
     emptyOutDir: true,
     rollupOptions: { input },
   },


### PR DESCRIPTION
I've found some issues around the latest changes on the vite config:

1. vite is building the assets inside the 'src' instead of the root folder, adding back resolve(process.cwd()) solves the issue
2. the js of templates trow an error at build time, adding a missing 'src/' solves the issue

You might have a better approach of this depending on your initial idea behind it, but these changes fixes my setup's